### PR TITLE
Extend AppWrapperLifecycleFnProps interface with appWrapperData

### DIFF
--- a/src/app/interfaces/AppWrapperLifecycleFnProps.ts
+++ b/src/app/interfaces/AppWrapperLifecycleFnProps.ts
@@ -10,6 +10,11 @@ export interface AppWrapperLifecycleFnProps<RegProps = unknown> extends AppLifec
      * See more details in [ILC App Wrappers documentation](https://github.com/namecheap/ilc/blob/master/docs/app_wrappers.md).
      */
     renderApp: <T = CustomProps>(props: T) => Promise<void>;
+    /**
+     * The appWrapperData object identifies that application execution is controlled by Wrapper
+     * The namespace contains params that identifies Wrapper
+     * appWrapperData.appId identifier of Wrapper
+     */
     appWrapperData?: {
         appId: string;
     };

--- a/src/app/interfaces/AppWrapperLifecycleFnProps.ts
+++ b/src/app/interfaces/AppWrapperLifecycleFnProps.ts
@@ -10,4 +10,7 @@ export interface AppWrapperLifecycleFnProps<RegProps = unknown> extends AppLifec
      * See more details in [ILC App Wrappers documentation](https://github.com/namecheap/ilc/blob/master/docs/app_wrappers.md).
      */
     renderApp: <T = CustomProps>(props: T) => Promise<void>;
+    appWrapperData?: {
+        appId: string;
+    };
 }


### PR DESCRIPTION
The problem is WrapperApp can not read pre-populated SSR state because it tries to read it using Application identifier not Wrapper's. So idea is to create namespace that will allow to extend Wrapper Props. 